### PR TITLE
Make the $contextly class a global so that we can hook into remove_ac…

### DIFF
--- a/contextly-linker.php
+++ b/contextly-linker.php
@@ -32,5 +32,6 @@ if ( is_admin() ) {
 }
 
 // Init Contextly
+global $contextly; 
 $contextly = new Contextly();
 $contextly->init();


### PR DESCRIPTION
Make the $contextly class a global so that we can hook into remove_action when using the plugin.
